### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 jcors-loader (v.1.2.0)
 ======================
-Little tiny loader for javascript sources using CORS (only 1.2KB plane and 673 with Gzip)
+Little tiny loader for javascript sources using CORS (only 1.2KB plain and 673 with Gzip)
 
 Goals
 ------------------
 - Load javascript files asynchronously in parallel.
 - Execute javascript in order.
 - Doesn't block window.onload or DOMContentLoaded. *
-- Soport in Safari, Chrome, Firefox, Opera, IE6+. *
+- Support in Safari, Chrome, Firefox, Opera, IE6+. *
 - No loading indicators, the page looks done and whenever the script arrives.
 - JSLint validation.
 


### PR DESCRIPTION
## Summary
- fix small typos in initial description of README

## Testing
- `grep -n "plain" -n README.md`
- `grep -n "Support in Safari" README.md`